### PR TITLE
fix duplicat of classd inventory

### DIFF
--- a/Commands.cs
+++ b/Commands.cs
@@ -139,12 +139,7 @@ namespace SCPReplacer
                     _ => RoleTypeId.FacilityGuard
                 };
                 response = $"You became a {newRole}";
-                scpPlayer.Role.Set(newRole, Exiled.API.Enums.SpawnReason.LateJoin, RoleSpawnFlags.All);
-                if (newRole is RoleTypeId.ClassD)
-                {
-                    scpPlayer.AddItem(ItemType.Flashlight);
-                    scpPlayer.AddItem(ItemType.Coin);
-                }
+                scpPlayer.Role.Set(newRole, Exiled.API.Enums.SpawnReason.LateJoin, RoleSpawnFlags.All);                
                 foreach (CustomRole custom in scpPlayer.GetCustomRoles())
                     custom.RemoveRole(scpPlayer);
                 scpPlayer.Broadcast(10, Plugin.Singleton.Translation.BroadcastHeader + $"You became a <color={newRole.GetColor().ToHex()}>{newRole.GetFullName()}</color>");


### PR DESCRIPTION
removed the code that checked is the human role is a class d and add the flashlight and coin. this is not needed because the setrole has all flags and reset the inventory by default. so the class d has double the inventory